### PR TITLE
fix: use storage-zone-password instead of access-key for edge storage requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The required inputs could be different depending on the feature flag(s) that you
 
 > **Warning** ⚠️
 >
-> Unfortunately I didn't found an option in Bunny to rollback the changes that can be made with this GitHub Action. \
+> Unfortunately I didn't found an option in Bunny to rollback the changes that can be made with this GitHub Action.
 > When something fails while running this action, you might have to manually fix it yourself.
 
 ## Example upload with delete and purge
@@ -30,6 +30,7 @@ See for more examples: [Examples](#examples)
     directory-to-upload: "./build"
     storage-endpoint: "storage.bunnycdn.com"
     storage-zone-name: "my-storage-zone"
+    storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
     concurrency: "50"
     enable-delete-action: true
     enable-purge-pull-zone: true
@@ -47,9 +48,9 @@ See for more examples: [Examples](#examples)
     <th>Description</th>
   </tr>
   <tr>
-    <td>access-key</td>
+    <td>storage-zone-password</td>
     <td>
-      Your bunny.net storage zone API key. This is necessary for the network requests that needs to be made to Bunny. See for more info: <a href="https://docs.bunny.net/reference/put_-storagezonename-path-filename#request-headers">Bunny Request headers</a>. This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run). Do not set this as plain text, save this as a secret in GitHub and reference here the secret id. See for more info: <a href="https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow">Using secrets in a workflow</a>. In case you still have doubts, check the source code and pin this action to a full length commit SHA. See for more info: <a href="https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions">Using third-party actions</a> about pinning an action to a full length commit SHA.
+      Your bunny.net storage zone password, you can find this in the storage zone details page FTP & API Access. It should have read & write access, otherwise it can't upload files for example. This is necessary for edge storage API requests that needs to be made to Bunny. See for more info: <a href="https://docs.bunny.net/reference/storage-api#header-name-accesskey">authentication header</a> in the docs. This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run). Do not set this as plain text, save this as a secret in GitHub and reference here the secret id. See for more info: <a href="https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow">Using secrets in a workflow</a>. In case you still have doubts, check the source code and pin this action to a full length commit SHA. See for more info: <a href="https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions">Using third-party actions</a> about pinning an action to a full length commit SHA.
     </td>
   </tr>
   <tr>
@@ -80,7 +81,7 @@ See for more examples: [Examples](#examples)
   <tr>
     <td>access-key</td>
     <td>
-      Your bunny.net storage zone API key. This is necessary for the network requests that needs to be made to Bunny. See for more info: <a href="https://docs.bunny.net/reference/put_-storagezonename-path-filename#request-headers">Bunny Request headers</a>. This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run). Do not set this as plain text, save this as a secret in GitHub and reference here the secret id. See for more info: <a href="https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow">Using secrets in a workflow</a>. In case you still have doubts, check the source code and pin this action to a full length commit SHA. See for more info: <a href="https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions">Using third-party actions</a> about pinning an action to a full length commit SHA.
+      Your bunny.net storage zone API key. This is necessary for the network requests that needs to be made to Bunny. See for more info: <a href="https://docs.bunny.net/reference/bunnynet-api-overview#header-name-accesskey">authentication header</a> in the docs. This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run). Do not set this as plain text, save this as a secret in GitHub and reference here the secret id. See for more info: <a href="https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow">Using secrets in a workflow</a>. In case you still have doubts, check the source code and pin this action to a full length commit SHA. See for more info: <a href="https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions">Using third-party actions</a> about pinning an action to a full length commit SHA.
     </td>
   </tr>
   <tr>
@@ -143,7 +144,7 @@ See for more examples: [Examples](#examples)
 - name: Upload build to Bunny
   uses: R-J-dev/bunny-deploy@v1
   with:
-    access-key: ${{ secrets.BUNNY_ACCESS_KEY }}
+    storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
     directory-to-upload: "./build"
     storage-endpoint: "storage.bunnycdn.com"
     storage-zone-name: "my-storage-zone"
@@ -160,6 +161,7 @@ See for more examples: [Examples](#examples)
     directory-to-upload: "./build"
     storage-endpoint: "storage.bunnycdn.com"
     storage-zone-name: "my-storage-zone"
+    storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
     concurrency: "50"
     enable-delete-action: true
     enable-purge-pull-zone: true

--- a/action.yml
+++ b/action.yml
@@ -8,47 +8,71 @@ branding:
 
 inputs:
   access-key:
+    required: false
     description: "Your bunny.net storage zone API key.
       This is necessary for the network requests that needs to be made to Bunny.
-      See for more info: https://docs.bunny.net/reference/put_-storagezonename-path-filename#request-headers.
+      See for more info: https://docs.bunny.net/reference/bunnynet-api-overview#header-name-accesskey.
       This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run).
       Do not set this as plain text, save this as a secret in GitHub and reference here the secret id.
       See for more info: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow.
       In case you still have doubts, check the source code and pin this action to a full length commit SHA.
       See for more info: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions about pinning an action to a full length commit SHA."
   directory-to-upload:
+    required: false
     description: "The path to the directory that needs to be uploaded to Bunny. An absolute path is preferred, but otherwise the action will combine the GITHUB_WORKSPACE with this input."
   storage-endpoint:
+    required: false
     description: "The storage API endpoint of your primary storage region. See for more info: https://docs.bunny.net/reference/storage-api#storage-endpoints."
   storage-zone-name:
+    required: false
     description: "The name of your storage zone, to determine to which storage zone the static app needs to upload."
+  storage-zone-password:
+    required: false
+    description:
+      "Your bunny.net storage zone password, you can find this in the storage zone details page FTP & API Access.
+      It should have read & write access, otherwise it can't upload files for example.
+      This is necessary for edge storage API requests that needs to be made to Bunny.
+      See for more info: https://docs.bunny.net/reference/bunnynet-api-overview#header-name-accesskey.
+      This will be read in src/config/config.ts, setSecret is used to mask it from logs (in case it will be logged by accident in your action run).
+      Do not set this as plain text, save this as a secret in GitHub and reference here the secret id.
+      See for more info: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow.
+      In case you still have doubts, check the source code and pin this action to a full length commit SHA.
+      See for more info: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions about pinning an action to a full length commit SHA."
   target-directory:
+    required: false
     description:
       "The directory path where the files from directory-to-upload needs to be uploaded to inside your storage zone.
       When the target-directory hasn't been passed or is an empty string, then the directory-to-upload will be uploaded to the root of your storage zone."
   pull-zone-id:
+    required: false
     description: "The pull zone id is required for purging the cache."
   replication-timeout:
+    required: false
     description: "The amount of seconds to wait before purging the cache.
       Unfortunately Bunny doesn't provide an api endpoint yet to check if the replicated storage zones are on the latest version (equal to main storage zone).
       See for more info: https://support.bunny.net/hc/en-us/articles/360020526159-Understanding-Geo-Replication.
       As you can read in the before mentioned link, an uploaded file should be replicated to other regions within a couple of seconds.
       So I think it should be safe to set this to 15 seconds, but check what works best for you."
   concurrency:
+    required: false
     description:
       "The maximum amount of concurrent actions (retrieving remote file info, deleting files, uploading files).
       For example this action can upload files using concurrency, but it depends on the GitHub runner and the API limit how much concurrent requests are possible.
       At Bunny the limit for concurrent uploads per storage zone seems to be 50.
       See for more info: https://docs.bunny.net/reference/edge-storage-api-limits."
   enable-delete-action:
+    required: false
     description:
       "Removes directories and files from your storage zone that do not exist in the specified directory-to-upload.
       This action compares the contents of the storage zone against the local directory and deletes any files that are present in the storage zone but absent from the local directory."
   enable-purge-pull-zone:
+    required: false
     description: "Purges the cache of the given pull-zone-id when all actions have finished."
   enable-purge-only:
+    required: false
     description: "Only enables the action to purge the pull zone cache of the given pull-zone-id and doesn't execute any other actions."
   disable-type-validation:
+    required: false
     description: "Disables type validation when the action retrieves file info.
       You probably will not need to disable the type validation,
       but in case Bunny changes their API and the action doesn't break due to the changes,

--- a/dist/index.js
+++ b/dist/index.js
@@ -45249,10 +45249,10 @@ const transformDirectoryToUploadInput = async (directoryToUpload) => {
 
 
 
-const getSecrets = async () => {
-    const accessKey = (0,core.getInput)("access-key", { required: true });
-    (0,core.setSecret)(accessKey);
-    return { accessKey };
+const getSecret = async (secretName) => {
+    const secret = (0,core.getInput)(secretName, { required: true });
+    (0,core.setSecret)(secret);
+    return secret;
 };
 const getFeatureFlags = async () => {
     logDebug("Retrieving feature flags");
@@ -45265,7 +45265,7 @@ const getFeatureFlags = async () => {
 };
 const getPullZoneConfig = async () => {
     logDebug("Retrieving pullZoneConfig");
-    const { accessKey } = await getSecrets();
+    const accessKey = await getSecret("access-key");
     const pullZoneId = await getInputWrapper({
         inputName: "pull-zone-id",
         inputOptions: { required: true },
@@ -45288,8 +45288,7 @@ const getPullZoneConfig = async () => {
 };
 const getEdgeStorageConfig = async () => {
     logDebug("Retrieving edgeStorageConfig");
-    const { accessKey } = await getSecrets();
-    // TODO: get storageZonePassword here instead of accessKey, getPullZoneConfig needs the accessKey
+    const storageZonePassword = await getSecret("storage-zone-password");
     const storageEndpoint = await getInputWrapper({
         inputName: "storage-endpoint",
         inputOptions: { required: true },
@@ -45309,7 +45308,7 @@ const getEdgeStorageConfig = async () => {
             validator: validateDirectory,
             errorLogMessage: "The directory-to-upload path isn't a valid path to an existing directory or doesn't have read access.",
         }),
-        edgeStorageClient: getBunnyClient(accessKey, storageEndpoint),
+        edgeStorageClient: getBunnyClient(storageZonePassword, storageEndpoint),
         storageZoneName: (0,core.getInput)("storage-zone-name", { required: true }),
         targetDirectory: await getInputWrapper({
             inputName: "target-directory",

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -110,7 +110,7 @@ describe("config", () => {
 
   describe("getEdgeStorageConfig", () => {
     const testConfig = {
-      "access-key": "test-access-key",
+      "storage-zone-password": "test-storage-zone-password",
       "storage-zone-name": "test-zone",
       "target-directory": "/test/target",
       "storage-endpoint": "https://example.com",
@@ -145,7 +145,7 @@ describe("config", () => {
 
     describe("Missing required config", () => {
       it.each([
-        ["access-key"],
+        ["storage-zone-password"],
         ["storage-endpoint"],
         ["concurrency"],
         ["directory-to-upload"],

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,11 +11,10 @@ import { getInputWrapper } from "@/config/inputWrapper.js";
 import { transformDirectoryToUploadInput } from "@/config/transformers.js";
 import { logDebug } from "@/logger.js";
 
-export const getSecrets = async () => {
-  const accessKey = getInput("access-key", { required: true });
-  setSecret(accessKey);
-
-  return { accessKey };
+export const getSecret = async (secretName: string) => {
+  const secret = getInput(secretName, { required: true });
+  setSecret(secret);
+  return secret;
 };
 
 export const getFeatureFlags = async () => {
@@ -30,7 +29,7 @@ export const getFeatureFlags = async () => {
 
 export const getPullZoneConfig = async () => {
   logDebug("Retrieving pullZoneConfig");
-  const { accessKey } = await getSecrets();
+  const accessKey = await getSecret("access-key");
   const pullZoneId = await getInputWrapper({
     inputName: "pull-zone-id",
     inputOptions: { required: true },
@@ -57,8 +56,7 @@ export const getPullZoneConfig = async () => {
 
 export const getEdgeStorageConfig = async () => {
   logDebug("Retrieving edgeStorageConfig");
-  const { accessKey } = await getSecrets();
-  // TODO: get storageZonePassword here instead of accessKey, getPullZoneConfig needs the accessKey
+  const storageZonePassword = await getSecret("storage-zone-password");
   const storageEndpoint = await getInputWrapper({
     inputName: "storage-endpoint",
     inputOptions: { required: true },
@@ -80,7 +78,7 @@ export const getEdgeStorageConfig = async () => {
       errorLogMessage:
         "The directory-to-upload path isn't a valid path to an existing directory or doesn't have read access.",
     }),
-    edgeStorageClient: getBunnyClient(accessKey, storageEndpoint),
+    edgeStorageClient: getBunnyClient(storageZonePassword, storageEndpoint),
     storageZoneName: getInput("storage-zone-name", { required: true }),
     targetDirectory: await getInputWrapper({
       inputName: "target-directory",


### PR DESCRIPTION
It seems that the account access-key can't be used for edge storage zone requests and the action should use the storage-zone-password for those actions. To fix this, I added an extra input option to set the storage-zone-password.

In the action.yml I also changed all the inputs to be optional, because the required inputs depend on the chosen feature flags. In the readme it's already clear which inputs are required for specific actions.