### PR TITLE
ci: update install-dependencies action

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: corepack enable pnpm && pnpm -v
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4.0.1
+      uses: actions/setup-node@v4.0.2
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"


### PR DESCRIPTION
Should fix the notice in the pipeline telling that Node.js 16 actions are deprecated.