### PR TITLE
ci: move e2e test to separate workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,46 @@
+name: E2E tests
+
+on:
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: ["PR validation"]
+    types:
+      - completed
+
+jobs:
+  e2e-test:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && ((github.event.review.state == 'approved' && github.event.review.author_association == 'OWNER') || github.event.workflow_run.actor.name == github.repository_owner) }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+    concurrency:
+      group: e2e-test
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+      - name: Generate random files to upload
+        run: |
+          set -euo pipefail
+          random_dir=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
+          mkdir -p ./.github/e2e-test-dir/$random_dir
+          echo "test" > ./.github/e2e-test-dir/$random_dir/file1.txt
+          random_nested_dir=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
+          mkdir -p ./.github/e2e-test-dir/$random_dir/$random_nested_dir
+          echo "test" > ./.github/e2e-test-dir/$random_dir/$random_nested_dir/file2.txt
+      - name: Deploy to Bunny
+        uses: ./
+        with:
+          storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
+          directory-to-upload: "./.github/e2e-test-dir/"
+          storage-endpoint: "https://storage.bunnycdn.com"
+          storage-zone-name: "r-j-dev-bunny-deploy-test"
+          concurrency: "50"
+          enable-delete-action: true
+          target-directory: "/e2e-test/"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -76,38 +76,3 @@ jobs:
           author_email: ${{ github.event.pull_request.user.email }}
           message: "build: update build"
           add: "dist/**"
-  e2e-test:
-    strategy:
-      max-parallel: 1
-      matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
-    concurrency:
-      group: e2e-test
-      cancel-in-progress: false
-    permissions:
-      contents: write
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.6
-      - name: Generate random files to upload
-        run: |
-          set -euo pipefail
-          random_dir=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
-          mkdir -p ./.github/e2e-test-dir/$random_dir
-          echo "test" > ./.github/e2e-test-dir/$random_dir/file1.txt
-          random_nested_dir=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
-          mkdir -p ./.github/e2e-test-dir/$random_dir/$random_nested_dir
-          echo "test" > ./.github/e2e-test-dir/$random_dir/$random_nested_dir/file2.txt
-      - name: Deploy to Bunny
-        uses: ./
-        with:
-          storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
-          directory-to-upload: "./.github/e2e-test-dir/"
-          storage-endpoint: "https://storage.bunnycdn.com"
-          storage-zone-name: "r-j-dev-bunny-deploy-test"
-          concurrency: "50"
-          enable-delete-action: true
-          target-directory: "/e2e-test/"


### PR DESCRIPTION
The e2e tests needs access to a secret. PR's from dependabot and forks can't access secrets. To fix this, e2e tests needs to be triggered by someone who has access to the secrets. In this case that is the person who also reviews the code.