### PR TITLE
ci: add ossf scorecard-action

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,7 +1,0 @@
-name: "Checkout"
-description: "Wraps the checkout action. This way it's easier to update the actual action."
-runs:
-  using: "composite"
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4.1.6

--- a/.github/actions/license-check/action.yml
+++ b/.github/actions/license-check/action.yml
@@ -1,0 +1,8 @@
+name: "License check"
+description: "Checks if all production licenses comply with the licenses that are marked as allowed in the project"
+runs:
+  using: "composite"
+  steps:
+    - name: Check all production licenses
+      shell: bash
+      run: pnpm license-checker-rseidelsohn --onlyAllow 'MIT' --production --excludePackages 'bunny-deploy@0.0.0-semantically-released'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Checking dependencies for disallowed licenses
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Validate formatting
@@ -48,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Validate linting rules
@@ -58,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Test actions

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,13 +20,14 @@ jobs:
         uses: actions/checkout@v4.1.7
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
+      - name: Checking dependencies for disallowed licenses
+        uses: ./.github/actions/license-check
       - name: Review new dependencies
         uses: actions/dependency-review-action@v4.3.3
         with:
-          allow-licenses: MIT
           fail-on-severity: low
           fail-on-scopes: runtime
-          license-check: true
+          license-check: false
           vulnerability-check: true
           comment-summary-in-pr: always
       - name: Checking dependencies for security issues

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Checking dependencies for disallowed licenses
-        shell: bash
-        run: pnpm license-checker-rseidelsohn --onlyAllow 'MIT' --production --excludePackages 'bunny-deploy@0.0.0-semantically-released'
+        uses: ./.github/actions/license-check
       - name: Checking dependencies for security issues
         run: pnpm audit
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
       - name: Checking dependencies for disallowed licenses

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,70 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "40 19 * * 5"
+  push:
+    branches: ["main"]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2.3.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@3.25.10
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bunny-deploy
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/R-J-dev/bunny-deploy/badge)](https://scorecard.dev/viewer/?uri=github.com/R-J-dev/bunny-deploy)
+
 GitHub action for deploying your static app to Bunny CDN 🚀
 
 ✔️ Uploads a given directory to a storage zone on Bunny \


### PR DESCRIPTION
Adds the ossf scorecard-action which should give an indication about how secure the project is. Also added a badge to the readme, which should show the result of the ossf scorecard-action. See fore more info: https://github.com/ossf/scorecard?tab=readme-ov-file#what-is-scorecard.

Also replaced the current license check from the dependency-review-action with the one that was used before, because I only want to check production dependencies.

Small extra changes:
- Removed unused composite checkout action
- Set persist-credentials to false on checkout action where possible