### PR TITLE
Add property based tests to config and fix discovered errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ deploy:
         enable-delete-action: true
         enable-purge-pull-zone: true
         pull-zone-id: "12345"
-        replication-timeout: "15"
+        replication-timeout: "15000"
 ```
 
 ## Config
@@ -101,7 +101,7 @@ deploy:
   <tr>
     <td>replication-timeout</td>
     <td>
-      The amount of seconds to wait before purging the cache. Unfortunately Bunny doesn't provide an api endpoint yet to check if the replicated storage zones are on the latest version (equal to main storage zone). See for more info: <a href="https://support.bunny.net/hc/en-us/articles/360020526159-Understanding-Geo-Replication">Understanding Geo-Replication</a>. As you can read in the before mentioned link, an uploaded file should be replicated to other regions within a couple of seconds. So I think it should be safe to set this to 15 seconds, but check what works best for you.
+      The amount of milliseconds to wait before purging the cache. Unfortunately Bunny doesn't provide an api endpoint yet to check if the replicated storage zones are on the latest version (equal to main storage zone). See for more info: <a href="https://support.bunny.net/hc/en-us/articles/360020526159-Understanding-Geo-Replication">Understanding Geo-Replication</a>. As you can read in the before mentioned link, an uploaded file should be replicated to other regions within a couple of seconds. So I think it should be safe to set this to 15000 milliseconds (15 seconds), but check what works best for you.
     </td>
   </tr>
 </table>
@@ -192,7 +192,7 @@ deploy:
         enable-delete-action: true
         enable-purge-pull-zone: true
         pull-zone-id: "12345"
-        replication-timeout: "15"
+        replication-timeout: "15000"
 ```
 
 ### Purge only
@@ -213,7 +213,7 @@ purge:
         disable-upload: true
         enable-purge-pull-zone: true
         pull-zone-id: "12345"
-        replication-timeout: "15"
+        replication-timeout: "15000"
 ```
 
 ## More detailed information about how this action works

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,11 @@ inputs:
     description: "The pull zone id is required for purging the cache."
   replication-timeout:
     required: false
-    description: "The amount of seconds to wait before purging the cache.
+    description: "The amount of milliseconds to wait before purging the cache.
       Unfortunately Bunny doesn't provide an api endpoint yet to check if the replicated storage zones are on the latest version (equal to main storage zone).
       See for more info: https://support.bunny.net/hc/en-us/articles/360020526159-Understanding-Geo-Replication.
       As you can read in the before mentioned link, an uploaded file should be replicated to other regions within a couple of seconds.
-      So I think it should be safe to set this to 15 seconds, but check what works best for you."
+      So I think it should be safe to set this to 15000 milliseconds (15 seconds), but check what works best for you."
   concurrency:
     required: false
     description:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "commitlint": "19.4.1",
     "eslint": "9.9.1",
     "eslint-config-prettier": "9.1.0",
-    "express": "4.19.2",
+    "express": "4.21.0",
     "fast-check": "3.22.0",
     "fs-extra": "11.2.0",
     "get-port": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "9.9.1",
     "eslint-config-prettier": "9.1.0",
     "express": "4.19.2",
+    "fast-check": "3.22.0",
     "fs-extra": "11.2.0",
     "get-port": "7.1.0",
     "globals": "15.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: 9.1.0
         version: 9.1.0(eslint@9.9.1(jiti@1.21.6))
       express:
-        specifier: 4.19.2
-        version: 4.19.2
+        specifier: 4.21.0
+        version: 4.21.0
       fast-check:
         specifier: 3.22.0
         version: 3.22.0
@@ -916,8 +916,8 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
-  body-parser@1.20.2:
-    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bottleneck@2.19.5:
@@ -1219,6 +1219,10 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   env-ci@11.0.0:
     resolution: {integrity: sha512-apikxMgkipkgTvMdRT9MNqWx5VLOci79F4VBd7Op/7OPjjoanjdAvn6fglMCCEf/1bAh8eOiuEVCUs4V3qP3nQ==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -1341,8 +1345,8 @@ packages:
     resolution: {integrity: sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==}
     engines: {node: '>=18'}
 
-  express@4.19.2:
-    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
+  express@4.21.0:
+    resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
 
   fast-check@3.22.0:
@@ -1381,8 +1385,8 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@1.2.0:
-    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
 
   find-up-simple@1.0.0:
@@ -1971,8 +1975,8 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
-  merge-descriptors@1.0.1:
-    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -2321,8 +2325,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.7:
-    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+  path-to-regexp@0.1.10:
+    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2396,8 +2400,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -2526,12 +2530,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.18.0:
-    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
-  serve-static@1.15.0:
-    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
 
   set-function-length@1.2.2:
@@ -3885,7 +3889,7 @@ snapshots:
 
   before-after-hook@3.0.2: {}
 
-  body-parser@1.20.2:
+  body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -3895,7 +3899,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.11.0
+      qs: 6.13.0
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -4190,6 +4194,8 @@ snapshots:
 
   encodeurl@1.0.2: {}
 
+  encodeurl@2.0.0: {}
+
   env-ci@11.0.0:
     dependencies:
       execa: 8.0.1
@@ -4413,34 +4419,34 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.0.2
 
-  express@4.19.2:
+  express@4.21.0:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.2
+      body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.2.0
+      finalhandler: 1.3.1
       fresh: 0.5.2
       http-errors: 2.0.0
-      merge-descriptors: 1.0.1
+      merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.7
+      path-to-regexp: 0.1.10
       proxy-addr: 2.0.7
-      qs: 6.11.0
+      qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
+      send: 0.19.0
+      serve-static: 1.16.2
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -4487,10 +4493,10 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.2.0:
+  finalhandler@1.3.1:
     dependencies:
       debug: 2.6.9
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
@@ -5053,7 +5059,7 @@ snapshots:
 
   meow@13.2.0: {}
 
-  merge-descriptors@1.0.1: {}
+  merge-descriptors@1.0.3: {}
 
   merge-stream@2.0.0: {}
 
@@ -5293,7 +5299,7 @@ snapshots:
       lru-cache: 10.2.2
       minipass: 7.1.2
 
-  path-to-regexp@0.1.7: {}
+  path-to-regexp@0.1.10: {}
 
   path-type@4.0.0: {}
 
@@ -5345,7 +5351,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.11.0:
+  qs@6.13.0:
     dependencies:
       side-channel: 1.0.6
 
@@ -5535,7 +5541,7 @@ snapshots:
 
   semver@7.6.2: {}
 
-  send@0.18.0:
+  send@0.19.0:
     dependencies:
       debug: 2.6.9
       depd: 2.0.0
@@ -5553,12 +5559,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.15.0:
+  serve-static@1.16.2:
     dependencies:
-      encodeurl: 1.0.2
+      encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.18.0
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       express:
         specifier: 4.19.2
         version: 4.19.2
+      fast-check:
+        specifier: 3.22.0
+        version: 3.22.0
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0
@@ -1342,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
 
+  fast-check@3.22.0:
+    resolution: {integrity: sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2385,6 +2392,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -4439,6 +4449,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-check@3.22.0:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.2:
@@ -5328,6 +5342,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qs@6.11.0:
     dependencies:

--- a/src/actions/pullZone/purge/purgeCache.ts
+++ b/src/actions/pullZone/purge/purgeCache.ts
@@ -12,7 +12,7 @@ interface PurgeCacheProps {
    */
   pullZoneId: string;
   /*
-   * The amount of seconds to wait before purging the cache.
+   * The amount of milliseconds to wait before purging the cache.
    * Unfortunately Bunny doesn't provide an api endpoint yet to check if the replicated storage zones are on the latest version (equal to main storage zone).
    * See for more info: https://support.bunny.net/hc/en-us/articles/360020526159-Understanding-Geo-Replication
    */
@@ -31,9 +31,9 @@ export const purgeCache = async ({
   const unexpectedError = `${whenDidTheErrorOccurred}, an unexpected error occurred`;
   try {
     logInfo(
-      `Waiting ${replicationTimeout} seconds before purging the cache, to make sure that the storage zones has been replicated.`,
+      `Waiting ${replicationTimeout} milliseconds before purging the cache, to make sure that the storage zones has been replicated.`,
     );
-    await setTimeout(replicationTimeout * 1000);
+    await setTimeout(replicationTimeout);
 
     logInfo("Purging the pull zone cache.");
     await client.post(`${pullZoneId}/purgeCache`);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -50,7 +50,7 @@ export const getPullZoneConfig = async () => {
   const replicationTimeout = await getInputWrapper({
     inputName: "replication-timeout",
     inputOptions: { required: true },
-    transformInput: async (input: string) => parseInt(input, 10),
+    transformInput: async (input: string) => Number(input),
     validator: validateInteger,
     errorLogMessage: "The replication-timeout is not a valid integer.",
   });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -74,7 +74,7 @@ export const getEdgeStorageConfig = async () => {
     concurrency: await getInputWrapper({
       inputName: "concurrency",
       inputOptions: { required: true },
-      transformInput: async (input: string) => parseInt(input, 10),
+      transformInput: async (input: string) => Number(input),
       validator: validatePositiveInteger,
     }),
     directoryToUpload: await getInputWrapper({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,6 +8,7 @@ import {
   validateDigitString,
   validatePositiveInteger,
   validateUrl,
+  validateStorageZoneName,
 } from "@/config/validators.js";
 import { getInputWrapper } from "@/config/inputWrapper.js";
 import {
@@ -16,7 +17,6 @@ import {
   transformDirectoryToUploadInput,
 } from "@/config/transformers.js";
 import { logDebug } from "@/logger.js";
-import { InvalidStorageZoneNameError } from "@/errors.js";
 
 export const getSecret = async (secretName: string) => {
   const secret = getInput(secretName, { required: true });
@@ -89,9 +89,7 @@ export const getEdgeStorageConfig = async () => {
     storageZoneName: await getInputWrapper({
       inputName: "storage-zone-name",
       inputOptions: { required: true },
-      validator: async (input: string) => {
-        if (input.includes("/")) throw new InvalidStorageZoneNameError();
-      },
+      validator: validateStorageZoneName,
     }),
     targetDirectory: await getInputWrapper({
       inputName: "target-directory",

--- a/src/config/validators.ts
+++ b/src/config/validators.ts
@@ -5,6 +5,7 @@ import {
   InvalidDigitStringError,
   InvalidPathError,
   InvalidUrlProtocolError,
+  InvalidStorageZoneNameError,
 } from "@/errors.js";
 import { lstat } from "node:fs/promises";
 
@@ -56,4 +57,8 @@ export const validateDirectory = async (path: string) => {
   const fileStats = await lstat(path);
   if (!fileStats.isDirectory())
     throw new InvalidPathError({ invalidPath: path });
+};
+
+export const validateStorageZoneName = async (name: string) => {
+  if (!/^[a-zA-Z0-9-]+$/.test(name)) throw new InvalidStorageZoneNameError();
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,7 +59,9 @@ export class InvalidPathError extends Error {
 }
 
 export class InvalidStorageZoneNameError extends Error {
-  constructor(message = "storage-zone-name should not contain a slash") {
+  constructor(
+    message = "storage-zone-name can only contain letters, numbers and dashes",
+  ) {
     super(message);
   }
 }

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -49,7 +49,7 @@ describe("main", () => {
     getPullZoneConfigSpy.mockResolvedValueOnce({
       pullZoneClient: vi.fn(),
       pullZoneId: 12345,
-      replicationTimeout: 15,
+      replicationTimeout: 15000,
     });
     fileInfoSpy.mockResolvedValue({
       unknownRemoteFiles: new Set<string>(),


### PR DESCRIPTION
Added the first property based tests to the config file and found already some invalid parsing and validation.
The library that is being used for these tests is called [fast-check](https://fast-check.dev/).

Fixes:

- Change replication-timeout to milliseconds
  - This should fix problems where decimal specified numbers like 20.5 were parsed to 20.
-  Invalid concurrency number parsing
   - When someone specified the concurrency as a number with decimals, it was parsed to an integer without any errors. After this fix, it will throw an error (in the before mentioned case) telling you to specify a positive integer instead.
- Invalid storage zone name validation
  - According to Bunny (when trying to add a new storage zone) storage zone names can only contain letters, numbers and dashes. Therefore the validation has changed.