### PR TITLE
ci: change dependency audit to prod only

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -32,8 +32,8 @@ jobs:
           license-check: false
           vulnerability-check: true
           comment-summary-in-pr: always
-      - name: Checking dependencies for security issues
-        run: pnpm audit
+      - name: Checking production dependencies for security issues
+        run: pnpm audit --prod
   format:
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/package.json
+++ b/package.json
@@ -38,17 +38,6 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "pnpm": {
-    "auditConfig": {
-      "ignoreCves": [
-        "CVE-2024-4067"
-      ]
-    },
-    "overrides": {
-      "vite@>=5.2.0 <5.2.14": ">=5.2.14",
-      "rollup@>=4.0.0 <4.22.4": ">=4.22.4"
-    }
-  },
   "devDependencies": {
     "@commitlint/cli": "19.5.0",
     "@commitlint/config-angular": "19.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  vite@>=5.2.0 <5.2.14: '>=5.2.14'
-  rollup@>=4.0.0 <4.22.4: '>=4.22.4'
-
 importers:
 
   .:
@@ -853,7 +849,7 @@ packages:
     peerDependencies:
       '@vitest/spy': 2.1.2
       msw: ^2.3.5
-      vite: '>=5.2.14'
+      vite: ^5.0.0
     peerDependenciesMeta:
       msw:
         optional: true


### PR DESCRIPTION
When pnpm audit fails on a dev dependency, it is usually not a problem. But it currently does block Dependabot PR's which should update dependencies and fixes most of the time the failed audit. Therefore, I chose to check only prod dependencies. The dev dependencies are already in some other checks, which doesn't block PR's and can still be monitored in that way.