### PR TITLE
ci: let release pipeline only check prod dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
         uses: ./.github/actions/install-dependencies
       - name: Checking dependencies for disallowed licenses
         uses: ./.github/actions/license-check
-      - name: Checking dependencies for security issues
-        run: pnpm audit
+      - name: Checking production dependencies for security issues
+        run: pnpm audit --prod
   release:
     name: Release
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Prod dependencies are only relevant for new releases, therefore changed the pnpm audit command to only check prod dependencies.