### PR TITLE
ci: dependabot and runner updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps-dev)"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
@@ -23,6 +26,8 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "github-actions"
+    commit-message:
+      prefix: "ci(deps-dev)"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,21 @@ updates:
       interval: "weekly"
     reviewers:
       - "R-J-dev"
+    groups:
+      commitlint:
+        patterns:
+          - "*commitlint*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      eslint:
+        patterns:
+          - "*eslint*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -110,15 +110,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        os:
-          [
-            ubuntu-20.04,
-            ubuntu-22.04,
-            ubuntu-24.04,
-            macos-12,
-            macos-13,
-            macos-14,
-          ]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
     concurrency:
       group: e2e-test
       cancel-in-progress: false

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "8.8.0",
     "@vercel/ncc": "0.38.2",
     "commitlint": "19.5.0",
+    "conventional-changelog-angular": "8.0.0",
     "eslint": "9.9.1",
     "eslint-config-prettier": "9.1.0",
     "express": "4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       commitlint:
         specifier: 19.5.0
         version: 19.5.0(@types/node@20.16.5)(typescript@5.6.3)
+      conventional-changelog-angular:
+        specifier: 8.0.0
+        version: 8.0.0
       eslint:
         specifier: 9.9.1
         version: 9.9.1(jiti@1.21.6)

--- a/release.config.js
+++ b/release.config.js
@@ -3,7 +3,22 @@
  */
 const config = {
   plugins: [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        preset: "angular",
+        releaseRules: [
+          // Default rules
+          { breaking: true, release: "major" },
+          { revert: true, release: "patch" },
+          { type: "feat", release: "minor" },
+          { type: "fix", release: "patch" },
+          { type: "perf", release: "patch" },
+          // Custom rule for production dependency updates
+          { type: "build", scope: "deps", release: "patch" },
+        ],
+      },
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github",
   ],


### PR DESCRIPTION
- Group Dependabot commitlint and eslint PRs
- Add Dependabot updates to releases
- Remove deprecated runner macos-12, to fix failing pipelines